### PR TITLE
Use a generic the way it's inferred

### DIFF
--- a/src/main/kotlin/me/shedaniel/linkie/utils/MappingsQuery.kt
+++ b/src/main/kotlin/me/shedaniel/linkie/utils/MappingsQuery.kt
@@ -18,7 +18,7 @@ import kotlin.math.pow
 
 data class MemberEntry<T : MappingsMember>(
     val owner: Class,
-    val member: MappingsMember,
+    val member: T,
 )
 
 typealias ClassResultList = List<ResultHolder<Class>>


### PR DESCRIPTION
Currently `MemberEntry<T : MappingsMember>` does not use its type variable. This simple PR fixes that by changing the `member` attribute from being a `MappingsMember` to being a `T`.